### PR TITLE
 Added unit tests for category services

### DIFF
--- a/.github/workflows/deployd.yml
+++ b/.github/workflows/deployd.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 jobs:
-  build-deploy-and-run-docker:
+  deployd:
     runs-on: ubuntu-latest
 
     steps:

--- a/src/main/java/com/consola/lis/dto/CategoryDTO.java
+++ b/src/main/java/com/consola/lis/dto/CategoryDTO.java
@@ -1,12 +1,15 @@
 package com.consola.lis.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 
 @Data
 @Builder
+@AllArgsConstructor
 public class CategoryDTO {
     @NotBlank(message = "Category name is required")
     private String categoryName;

--- a/src/main/java/com/consola/lis/model/entity/Category.java
+++ b/src/main/java/com/consola/lis/model/entity/Category.java
@@ -2,16 +2,13 @@ package com.consola.lis.model.entity;
 
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Data
 @Builder
+@Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Entity
 @Table(name="category", uniqueConstraints = {@UniqueConstraint(columnNames={"categoryName"})})
 public class Category {
     @Id

--- a/src/main/java/com/consola/lis/service/CategoryService.java
+++ b/src/main/java/com/consola/lis/service/CategoryService.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;

--- a/src/test/java/com/consola/lis/service/CategoryServiceTest.java
+++ b/src/test/java/com/consola/lis/service/CategoryServiceTest.java
@@ -1,10 +1,128 @@
 package com.consola.lis.service;
 
+import com.consola.lis.dto.CategoryDTO;
+import com.consola.lis.dto.ListAttributeDTO;
+import com.consola.lis.exception.AlreadyExistsException;
+import com.consola.lis.exception.NotExistingException;
+import com.consola.lis.model.entity.Category;
+import com.consola.lis.model.repository.CategoryRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class CategoryServiceTest {
 
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void testGetAllCategories() {
+        List<Category> categories = new ArrayList<>();
+        categories.add(new Category());
+        when(categoryRepository.findAll()).thenReturn(categories);
+
+        List<Category> result = categoryService.getAllCategories();
+
+        assertEquals(categories, result);
+    }
+
+    @Test
+    void testCreateCategory_Success() throws JsonProcessingException {
+
+        CategoryDTO categoryDTO= new CategoryDTO("Test Category",true,new String[]{"Attribute1"},new ListAttributeDTO[]{new ListAttributeDTO()});
+        when(categoryRepository.existsByCategoryName("Test Category")).thenReturn(false);
+        //act
+        categoryService.createCategory(categoryDTO);
+        //Assert
+        verify(categoryRepository, times(1)).save(any());
+    }
+
+    @Test
+    void testCreateCategory_CategoryAlreadyExists()  {
+
+        CategoryDTO categoryDTO= new CategoryDTO("Test Category",true,new String[]{"Attribute1"},new ListAttributeDTO[]{new ListAttributeDTO()});
+        when(categoryRepository.existsByCategoryName("Test Category")).thenReturn(true);
+
+        assertThrows(AlreadyExistsException.class, () -> categoryService.createCategory(categoryDTO));
+
+        verify(categoryRepository, never()).save(any());
+    }
+
+    @Test
+    void testDeleteCategory_CategoryExists() {
+
+        String categoryName = "Test";
+
+        when(categoryRepository.existsByCategoryName(categoryName)).thenReturn(true);
+
+        assertDoesNotThrow(() -> categoryService.deleteCategory(categoryName));
+        verify(categoryRepository, times(1)).deleteByCategoryName(categoryName);
+    }
+
+    @Test
+    public void testDeleteCategory_CategoryNotExists() {
+
+        String categoryName = "Test";
+
+        when(categoryRepository.existsByCategoryName(categoryName)).thenReturn(false);
+
+        assertThrows(NotExistingException.class, () -> categoryService.deleteCategory(categoryName));
+        verify(categoryRepository, never()).deleteByCategoryName(categoryName);
+    }
+
+    @Test
+    void testFindCategory_CategoryExists() {
+        String categoryName = "Test";
+        Category category = new Category();
+        category.setCategoryName(categoryName);
+
+        when(categoryRepository.findByCategoryName(categoryName)).thenReturn(Optional.of(category));
+
+        assertEquals(category, categoryService.findCategory(categoryName));
+    }
+
+    @Test
+    void testFindCategory_CategoryNotExists() {
+        String categoryName = "Test";
+
+        when(categoryRepository.findByCategoryName(categoryName)).thenReturn(Optional.empty());
+
+        assertThrows(NotExistingException.class, () -> categoryService.findCategory(categoryName));
+    }
+
+    @Test
+    void testGetCategoryNames_CategoriesExist() {
+        List<Category> categories = Arrays.asList(new Category(), new Category());
+        when(categoryRepository.findAll()).thenReturn(categories);
+
+        assertEquals(2, categoryService.getCategoryNames().size());
+    }
+
+    @Test
+    void testGetCategoryNames_NoCategoriesFound() {
+        when(categoryRepository.findAll()).thenReturn(Collections.emptyList());
+
+        assertThrows(NotExistingException.class, () -> categoryService.getCategoryNames());
+    }
 
 }

--- a/src/test/java/com/consola/lis/service/LoginServiceTest.java
+++ b/src/test/java/com/consola/lis/service/LoginServiceTest.java
@@ -6,13 +6,19 @@ import com.consola.lis.exception.UserAuthenticationException;
 import com.consola.lis.jwt.JwtService;
 import com.consola.lis.model.entity.User;
 import com.consola.lis.model.enums.UserRole;
+import com.consola.lis.model.repository.CategoryRepository;
 import com.consola.lis.model.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
@@ -31,6 +37,7 @@ class LoginServiceTest {
 
     private final LoginService authService = new LoginService(authenticationManager, userRepository, jwtService);
 
+
     @Test
     void login() {
         LoginRequestDTO loginRequest = new LoginRequestDTO("example_user", "password");
@@ -47,22 +54,20 @@ class LoginServiceTest {
         when(userRepository.findByUsername(loginRequest.getUsername())).thenReturn(java.util.Optional.of(user));
         when(jwtService.getToken(user)).thenReturn(token);
 
-        // Act
+
         AuthResponseDTO response = authService.login(loginRequest);
 
-        // Assert
         assertNotNull(response);
         assertEquals(token, response.getToken());
     }
 
     @Test
     void testLogin_AuthenticationFailure() {
-        // Arrange
+
         LoginRequestDTO loginRequest = new LoginRequestDTO("invalidUsername", "invalidPassword");
 
         when(userRepository.findByUsername(loginRequest.getUsername())).thenReturn(Optional.empty());
 
-        // Act & Assert
         assertThrows(UserAuthenticationException.class, () -> authService.login(loginRequest));
     }
 }

--- a/src/test/java/com/consola/lis/service/RegisterServiceTest.java
+++ b/src/test/java/com/consola/lis/service/RegisterServiceTest.java
@@ -6,12 +6,16 @@ import com.consola.lis.exception.AlreadyExistsException;
 import com.consola.lis.jwt.JwtService;
 import com.consola.lis.model.entity.User;
 import com.consola.lis.model.enums.UserRole;
+import com.consola.lis.model.repository.CategoryRepository;
 import com.consola.lis.model.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
@@ -23,18 +27,22 @@ import static org.mockito.Mockito.*;
 
 class RegisterServiceTest {
 
+    @Mock
+    private UserRepository userRepository;
 
+    @Mock
+    private JwtService jwtService;
 
-    private final UserRepository userRepository = mock(UserRepository.class);
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
-    private final JwtService jwtService = mock(JwtService.class);
+    @InjectMocks
+    private RegisterService registerService;
 
-
-    private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
-
-
-    private final RegisterService registerService = new RegisterService(userRepository, jwtService,passwordEncoder) ;
-
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
 
     @Test
     void testRegister_NewUser_SuccessfullyRegistered() {


### PR DESCRIPTION
###  This commit adds unit tests for the category services.

 The tests encompass different scenarios to ensure the
 correctness and robustness of the category-related functionalities.

-  [x]  Get all categories
-  [x]  Create ategory successfully
-  [x]  Category already exists
-  [x]  Delete category
-  [x]  Find category
-  [x]  Get category names
	 
> [!IMPORTANT]                                                                                                         
> To run the tests via the command line using                                                                          
 the command ```mvn test```, JDK 17 must be installed in your environment.                                               
Otherwise, run the tests through IntelliJ or another development IDE.