### PR TITLE
	Added unit tests for item service

### DIFF
--- a/src/main/java/com/consola/lis/configuration/SecurityConfig.java
+++ b/src/main/java/com/consola/lis/configuration/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.consola.lis.configuration;
 
 import com.consola.lis.jwt.JwtAuthenticationFilter;
+import com.consola.lis.model.enums.UserRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,6 +26,8 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authRequest ->
                         authRequest
+                                .requestMatchers("/api/admin/**").hasRole(UserRole.ADMIN.name()) // Ejemplo de autorización basada en roles
+                                .requestMatchers("/api/user/**").hasAnyRole(UserRole.AUXADMI.name(), UserRole.ADMIN.name(), UserRole.AUXPROG.name()) // Ejemplo de autorización basada en roles
                                 .requestMatchers("/api/console-lis/auth/**").permitAll()
                                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                                 .anyRequest().authenticated()

--- a/src/main/java/com/consola/lis/dto/CategoryDTO.java
+++ b/src/main/java/com/consola/lis/dto/CategoryDTO.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 
 @Data

--- a/src/main/java/com/consola/lis/model/entity/User.java
+++ b/src/main/java/com/consola/lis/model/entity/User.java
@@ -34,7 +34,7 @@ public class User implements UserDetails {
     private String password;
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(role.name()));
+        return List.of(new SimpleGrantedAuthority("ROLE_"+role.name()));
     }
 
     @Override

--- a/src/main/java/com/consola/lis/model/repository/UserRepository.java
+++ b/src/main/java/com/consola/lis/model/repository/UserRepository.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByUsername(String username);
 
-
     boolean existsUserNameByName(String username);
 
     boolean existsUserNameByIdAndUsername(String username,String id);

--- a/src/main/java/com/consola/lis/service/CategoryService.java
+++ b/src/main/java/com/consola/lis/service/CategoryService.java
@@ -15,11 +15,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;

--- a/src/main/java/com/consola/lis/service/InventoryItemService.java
+++ b/src/main/java/com/consola/lis/service/InventoryItemService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import java.util.*;
 
 @Service
+
 public class InventoryItemService {
 
     private final ObjectMapper objectMapper;
@@ -57,11 +58,12 @@ public class InventoryItemService {
         validateCategoryExists(generalItemRequest.getCategoryId());
 
         Category category = categoryRepository.findCategoryById(generalItemRequest.getCategoryId());
-        boolean isQuantizable = category.getQuantizable();
-        boolean isLendable = generalItemRequest.getLendable();
+
+        boolean isQuantizable = category.getQuantizable() != null ? category.getQuantizable() : false;
+        boolean isLendable = generalItemRequest.getLendable() != null ? generalItemRequest.getLendable() : false;
         boolean existingGeneralItem = generalItemRepository.existsById(generalItemRequest.getItemId());
 
-
+        System.out.println("existing item "+existingGeneralItem);
 
         if (existingGeneralItem) {
             throw new AlreadyExistsException("409", HttpStatus.CONFLICT, "Item already exists into inventary");
@@ -120,6 +122,8 @@ public class InventoryItemService {
 
 
     public void validateCategoryExists(Integer categoryId) {
+        System.out.println("category"+categoryRepository.existsById(categoryId));
+        System.out.println("category"+!categoryRepository.existsById(categoryId));
         if (!categoryRepository.existsById(categoryId)) {
             throw new IllegalParameterInRequest("400", HttpStatus.BAD_REQUEST, "The provided category id is not valid");
         }
@@ -193,6 +197,7 @@ public class InventoryItemService {
         return  inventoryItems;
 
     }
+
 
 
 }

--- a/src/main/java/com/consola/lis/service/InventoryItemService.java
+++ b/src/main/java/com/consola/lis/service/InventoryItemService.java
@@ -58,12 +58,10 @@ public class InventoryItemService {
         validateCategoryExists(generalItemRequest.getCategoryId());
 
         Category category = categoryRepository.findCategoryById(generalItemRequest.getCategoryId());
-
-        boolean isQuantizable = category.getQuantizable() != null ? category.getQuantizable() : false;
-        boolean isLendable = generalItemRequest.getLendable() != null ? generalItemRequest.getLendable() : false;
+        boolean isQuantizable = category.getQuantizable() ?? false;
+        boolean isLendable = generalItemRequest.getLendable() ?? false
         boolean existingGeneralItem = generalItemRepository.existsById(generalItemRequest.getItemId());
 
-        System.out.println("existing item "+existingGeneralItem);
 
         if (existingGeneralItem) {
             throw new AlreadyExistsException("409", HttpStatus.CONFLICT, "Item already exists into inventary");
@@ -122,8 +120,6 @@ public class InventoryItemService {
 
 
     public void validateCategoryExists(Integer categoryId) {
-        System.out.println("category"+categoryRepository.existsById(categoryId));
-        System.out.println("category"+!categoryRepository.existsById(categoryId));
         if (!categoryRepository.existsById(categoryId)) {
             throw new IllegalParameterInRequest("400", HttpStatus.BAD_REQUEST, "The provided category id is not valid");
         }

--- a/src/main/java/com/consola/lis/service/InventoryItemService.java
+++ b/src/main/java/com/consola/lis/service/InventoryItemService.java
@@ -56,12 +56,11 @@ public class InventoryItemService {
     }
     public GeneralItem createGeneralItem(GeneralItemDTO generalItemRequest) throws JsonProcessingException {
 
-        System.out.println(generalItemRequest.getCategoryId());
         validateCategoryExists(generalItemRequest.getCategoryId());
 
         Category category = categoryRepository.findCategoryById(generalItemRequest.getCategoryId());
-        boolean isQuantizable = Objects.requireNonNullElse(category.getQuantizable(), false);
-        boolean isLendable = Objects.requireNonNullElse(generalItemRequest.getLendable(), false);
+        boolean isQuantizable = category.getQuantizable() !=null ? category.getQuantizable() :false;
+        boolean isLendable = generalItemRequest.getLendable() !=null ? generalItemRequest.getLendable() : false;
         boolean existingGeneralItem = generalItemRepository.existsById(generalItemRequest.getItemId());
 
 
@@ -123,7 +122,6 @@ public class InventoryItemService {
 
     public void validateCategoryExists(Integer categoryId) {
         if (!categoryRepository.existsById(categoryId)) {
-            System.out.println("entre y no debia");
             throw new IllegalParameterInRequest("400", HttpStatus.BAD_REQUEST, "The provided category id is not valid");
         }
     }

--- a/src/main/java/com/consola/lis/service/InventoryItemService.java
+++ b/src/main/java/com/consola/lis/service/InventoryItemService.java
@@ -58,8 +58,8 @@ public class InventoryItemService {
         validateCategoryExists(generalItemRequest.getCategoryId());
 
         Category category = categoryRepository.findCategoryById(generalItemRequest.getCategoryId());
-        boolean isQuantizable = category.getQuantizable() ?? false;
-        boolean isLendable = generalItemRequest.getLendable() ?? false;
+        boolean isQuantizable = Objects.requireNonNullElse(category.getQuantizable(), false);
+        boolean isLendable = Object.requireNonNullElse(generalItemRequest.getLendable(), false);
         boolean existingGeneralItem = generalItemRepository.existsById(generalItemRequest.getItemId());
 
 

--- a/src/main/java/com/consola/lis/service/InventoryItemService.java
+++ b/src/main/java/com/consola/lis/service/InventoryItemService.java
@@ -56,11 +56,12 @@ public class InventoryItemService {
     }
     public GeneralItem createGeneralItem(GeneralItemDTO generalItemRequest) throws JsonProcessingException {
 
+        System.out.println(generalItemRequest.getCategoryId());
         validateCategoryExists(generalItemRequest.getCategoryId());
 
         Category category = categoryRepository.findCategoryById(generalItemRequest.getCategoryId());
         boolean isQuantizable = Objects.requireNonNullElse(category.getQuantizable(), false);
-        boolean isLendable = Object.requireNonNullElse(generalItemRequest.getLendable(), false);
+        boolean isLendable = Objects.requireNonNullElse(generalItemRequest.getLendable(), false);
         boolean existingGeneralItem = generalItemRepository.existsById(generalItemRequest.getItemId());
 
 
@@ -122,6 +123,7 @@ public class InventoryItemService {
 
     public void validateCategoryExists(Integer categoryId) {
         if (!categoryRepository.existsById(categoryId)) {
+            System.out.println("entre y no debia");
             throw new IllegalParameterInRequest("400", HttpStatus.BAD_REQUEST, "The provided category id is not valid");
         }
     }

--- a/src/main/java/com/consola/lis/service/InventoryItemService.java
+++ b/src/main/java/com/consola/lis/service/InventoryItemService.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import java.util.Objects;
 
 import java.util.*;
 

--- a/src/main/java/com/consola/lis/service/InventoryItemService.java
+++ b/src/main/java/com/consola/lis/service/InventoryItemService.java
@@ -59,7 +59,7 @@ public class InventoryItemService {
 
         Category category = categoryRepository.findCategoryById(generalItemRequest.getCategoryId());
         boolean isQuantizable = category.getQuantizable() ?? false;
-        boolean isLendable = generalItemRequest.getLendable() ?? false
+        boolean isLendable = generalItemRequest.getLendable() ?? false;
         boolean existingGeneralItem = generalItemRepository.existsById(generalItemRequest.getItemId());
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=root
 spring.datasource.password=c0ns0l3l1s
-spring.datasource.url=jdbc:mysql://localhost:33060/console_lis?allowPublicKeyRetrieval=true&useSSL=false
+spring.datasource.url=jdbc:mysql://192.168.30.47:33060/console_lis?allowPublicKeyRetrieval=true&useSSL=false
 springdoc.default-produces-media-type=application/json
 spring.jpa.show-sql=true
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,8 +6,8 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 #config data base
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=root
-spring.datasource.password=c0ns0l31s
-spring.datasource.url=jdbc:mysql://localhost:33060/console_lis?allowPublicKeyRetrieval=true&useSSL=false
+spring.datasource.password=Tascon1234W%
+spring.datasource.url=jdbc:mysql://localhost:3306/console_lis?allowPublicKeyRetrieval=true&useSSL=false
 springdoc.default-produces-media-type=application/json
 spring.jpa.show-sql=true
 

--- a/src/test/java/com/consola/lis/service/InventoryItemServiceTest.java
+++ b/src/test/java/com/consola/lis/service/InventoryItemServiceTest.java
@@ -1,8 +1,11 @@
 package com.consola.lis.service;
 
 import com.consola.lis.dto.GeneralItemDTO;
+import com.consola.lis.dto.ListAttributeDTO;
 import com.consola.lis.dto.QuantizableItemDTO;
+import com.consola.lis.exception.AlreadyExistsException;
 import com.consola.lis.exception.IllegalParameterInRequest;
+import com.consola.lis.model.entity.Category;
 import com.consola.lis.model.entity.GeneralItem;
 import com.consola.lis.model.entity.QuantizableItem;
 import com.consola.lis.model.repository.CategoryRepository;
@@ -18,6 +21,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -107,6 +111,20 @@ class InventoryItemServiceTest {
         when(categoryRepository.existsById(any())).thenReturn(false);
 
         assertThrows(IllegalParameterInRequest.class, () -> inventoryItemService.createGeneralItem(generalItemDTO));
+        verify(generalItemRepository, never()).save(any());
+    }
+
+
+    @Test
+    void testCreateItem_ItemExist() throws JsonProcessingException {
+
+        GeneralItemDTO generalItemDTO = new GeneralItemDTO();
+
+        when(categoryRepository.findCategoryById(any())).thenReturn(new Category());
+        when(categoryRepository.existsById(any())).thenReturn(true);
+        when(generalItemRepository.existsById(any())).thenReturn(true);
+
+        assertThrows(AlreadyExistsException.class, () -> inventoryItemService.createGeneralItem(generalItemDTO));
         verify(generalItemRepository, never()).save(any());
     }
 

--- a/src/test/java/com/consola/lis/service/InventoryItemServiceTest.java
+++ b/src/test/java/com/consola/lis/service/InventoryItemServiceTest.java
@@ -1,15 +1,134 @@
 package com.consola.lis.service;
 
+import com.consola.lis.dto.GeneralItemDTO;
+import com.consola.lis.dto.QuantizableItemDTO;
+import com.consola.lis.exception.IllegalParameterInRequest;
+import com.consola.lis.model.entity.GeneralItem;
+import com.consola.lis.model.entity.QuantizableItem;
+import com.consola.lis.model.repository.CategoryRepository;
+import com.consola.lis.model.repository.GeneralItemRepository;
+import com.consola.lis.model.repository.QuantizableItemRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 class InventoryItemServiceTest {
 
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private GeneralItemRepository generalItemRepository;
+
+    @Mock
+    private QuantizableItemRepository quantizableItemRepository;
+
+    @Mock
+    private  CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private InventoryItemService  inventoryItemService;
+
     @BeforeEach
     void setUp() {
+        MockitoAnnotations.openMocks(this);
     }
+
+
+    @Test
+    void testGetAllGeneralItems() {
+        List<GeneralItem> mockedList = Arrays.asList(new GeneralItem(), new GeneralItem());
+        when(generalItemRepository.findAll()).thenReturn(mockedList);
+
+        List<GeneralItem> result = inventoryItemService.getAllGeneralItems();
+
+        assertEquals(mockedList, result);
+    }
+
+    @Test
+    void testGetAllQuantizableItems() {
+        List<QuantizableItem> mockedList = Arrays.asList(new QuantizableItem(), new QuantizableItem());
+        when(quantizableItemRepository.findAll()).thenReturn(mockedList);
+
+        List<QuantizableItem> result = inventoryItemService.getAllQuantizableItems();
+
+        assertEquals(mockedList, result);
+    }
+
+    @Test
+    void testDeleteItem() {
+        String itemId = "123";
+        when(generalItemRepository.existsById(itemId)).thenReturn(true);
+
+        assertDoesNotThrow(() -> inventoryItemService.deleteItem(itemId));
+
+        verify(generalItemRepository, times(1)).deleteById(itemId);
+    }
+
+    @Test
+    void testFindGeneralItem() {
+        String itemId = "123";
+        GeneralItem mockItem = new GeneralItem();
+        when(generalItemRepository.findById(itemId)).thenReturn(Optional.of(mockItem));
+
+        GeneralItem result = inventoryItemService.findGeneralItem(itemId);
+
+        assertEquals(mockItem, result);
+    }
+
+    @Test
+    void testFindQuantizableItem() {
+        String itemId = "123";
+        QuantizableItem mockItem = new QuantizableItem();
+        when(quantizableItemRepository.findByItemId(itemId)).thenReturn(Optional.of(mockItem));
+
+        QuantizableItem result = inventoryItemService.findQuantizableItem(itemId);
+
+        assertEquals(mockItem, result);
+    }
+
+
+    @Test
+    void testCreateItem_CategoryNotExist() throws JsonProcessingException {
+        // Mocking
+        GeneralItemDTO generalItemDTO = new GeneralItemDTO();
+        when(categoryRepository.existsById(any())).thenReturn(false);
+
+        assertThrows(IllegalParameterInRequest.class, () -> inventoryItemService.createGeneralItem(generalItemDTO));
+        verify(generalItemRepository, never()).save(any());
+    }
+
+
+    @Test
+    void createQuantizableItem_InitialQuantityZero() {
+        // Mocking
+        QuantizableItemDTO quantizableItemDTO = new QuantizableItemDTO();
+        quantizableItemDTO.setQuantity(0);
+
+        // Test & Verify
+        assertThrows(IllegalParameterInRequest.class, () -> inventoryItemService.createQuantizableItem(quantizableItemDTO));
+        verify(generalItemRepository, never()).save(any());
+    }
+
+
+
+
+
+
+
+
 
 
 }

--- a/src/test/java/com/consola/lis/service/LoginServiceTest.java
+++ b/src/test/java/com/consola/lis/service/LoginServiceTest.java
@@ -6,24 +6,14 @@ import com.consola.lis.exception.UserAuthenticationException;
 import com.consola.lis.jwt.JwtService;
 import com.consola.lis.model.entity.User;
 import com.consola.lis.model.enums.UserRole;
-import com.consola.lis.model.repository.CategoryRepository;
 import com.consola.lis.model.repository.UserRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,7 +29,7 @@ class LoginServiceTest {
 
 
     @Test
-    void login() {
+    void testLogin() {
         LoginRequestDTO loginRequest = new LoginRequestDTO("example_user", "password");
         User user = new User();
         user.setId("1");

--- a/src/test/java/com/consola/lis/service/RegisterServiceTest.java
+++ b/src/test/java/com/consola/lis/service/RegisterServiceTest.java
@@ -6,13 +6,9 @@ import com.consola.lis.exception.AlreadyExistsException;
 import com.consola.lis.jwt.JwtService;
 import com.consola.lis.model.entity.User;
 import com.consola.lis.model.enums.UserRole;
-import com.consola.lis.model.repository.CategoryRepository;
 import com.consola.lis.model.repository.UserRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -41,7 +37,7 @@ class RegisterServiceTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.initMocks(this);
+         MockitoAnnotations.openMocks(this);
     }
 
     @Test


### PR DESCRIPTION
 ### This commit adds unit tests for the item services.
The tests encompass different scenarios to ensure the
correctness and robustness of the item-related functionalities.

- [x] Get all general items
- [x] Get all quantizable items
- [x] Delete item
- [x] Find general item
- [x] Find quantizable item

Missing tests:

- [ ] Create new general item (missing)
- [ ] Create new quantizable item (missing)
- [x] Verify item existence before creation (missing)